### PR TITLE
Update only the batch operations visible on the sync console

### DIFF
--- a/force-app/main/default/classes/MailchimpSyncController.cls
+++ b/force-app/main/default/classes/MailchimpSyncController.cls
@@ -194,7 +194,7 @@ public with sharing class MailchimpSyncController {
         redirect.setRedirect(true);
 
         MailchimpSyncManager mailchimp = new MailchimpSyncManager();
-        mailchimp.updateBatches(mailchimp.unfinishedBatches(50));
+        mailchimp.updateBatches(this.unfinishedBatchOperations);
 
         return redirect;
     }

--- a/force-app/main/default/pages/MailchimpSync.page
+++ b/force-app/main/default/pages/MailchimpSync.page
@@ -69,7 +69,7 @@
         <apex:pageBlock title="Mailchimp batch operations in progress">
             <apex:pageBlockButtons location="top">
                 <apex:commandButton action="{!URLFOR($Action.Mailchimp_Batch_Operation__c.List, $ObjectType.Mailchimp_Batch_Operation__c.keyPrefix)}" value="View all" />
-                <apex:commandButton action="{!updateBatches}" value="Update all" />
+                <apex:commandButton action="{!updateBatches}" value="Update" />
             </apex:pageBlockButtons>
             <apex:pageBlockTable var="batch" value="{!unfinishedBatchOperations}">
                 <apex:column>


### PR DESCRIPTION
The final bookkeeping step of the sync process, `MailchimpUpdateBatchesJob`, sometimes fails with an error:

> First error: Too many DML rows: 10001

With this change, we can use the 'Update' button on the sync console to update a smaller set of batches (namely, the 20 visible records). That lets the process move thru.

A fully-automated solution would involve changes to `MailchimpUpdateBatchesJob` to limit the number of batches it works on, and fire off another job if there are more left to process. The wrinkle there is that sometimes jobs get stuck in the 'finalizing' state. We'd need to guard against that, so it'd be more than the 5-minute fix that this was. Probably worthwhile to do it in the near term though.